### PR TITLE
Update project tt_um_algofoogle_tt08_vga_fun (algofoogle/tt08-vga-fun)

### DIFF
--- a/projects/tt_um_algofoogle_tt08_vga_fun/commit_id.json
+++ b/projects/tt_um_algofoogle_tt08_vga_fun/commit_id.json
@@ -1,8 +1,8 @@
 {
   "app": "custom_gds action",
   "repo": "https://github.com/algofoogle/tt08-vga-fun",
-  "commit": "c20434647f8a03c4ca0dbd78a67f2f6fd285e5ed",
-  "workflow_url": "https://github.com/algofoogle/tt08-vga-fun/actions/runs/10735855815",
+  "commit": "2146326ea1f37737ccfb8b8cec533b77a8a39da1",
+  "workflow_url": "https://github.com/algofoogle/tt08-vga-fun/actions/runs/10741020637",
   "sort_id": 1725195076949,
   "analog": true
 }


### PR DESCRIPTION
Update project tt_um_algofoogle_tt08_vga_fun to commit algofoogle/tt08-vga-fun@2146326ea1f37737ccfb8b8cec533b77a8a39da1

Project title: TT08 VGA FUN!
Tiles: 1x2
Workflow: https://github.com/algofoogle/tt08-vga-fun/actions/runs/10741020637

